### PR TITLE
[KZ4112] Adiciona timeout na request da gem da TWW

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,3 @@
 /tmp/
 .byebug_history
 *.gem
-.idea

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 /tmp/
 .byebug_history
 *.gem
+.idea

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,4 @@
+# v1.2.0
+
+## Alterações
+- [KZ4112] Adiciona timeout na request da gem da TWW

--- a/lib/tww/config.rb
+++ b/lib/tww/config.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module TWW
-  Config = Struct.new(:username, :password, :from, :layout) do
+  Config = Struct.new(:username, :password, :from, :layout, :timeout) do
     def merge(attributes = {})
       attributes.empty? ? self : dup.copy(attributes)
     end

--- a/lib/tww/response.rb
+++ b/lib/tww/response.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rexml/document'
 
 module TWW

--- a/lib/tww/rest.rb
+++ b/lib/tww/rest.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'restclient'
 require 'tww/client'
 
@@ -18,6 +20,7 @@ module TWW
     end
 
     private
+
     def call_params(phone, message, extras)
       now = Time.now.strftime('%Y-%m-%d %H:%M:%S')
 
@@ -50,7 +53,12 @@ module TWW
     end
 
     def request(url, params)
-      xml = RestClient.post(url, params)
+      xml = RestClient::Request.new(
+        method: :post,
+        url: url,
+        payload: params,
+        timeout: config.timeout
+      ).execute
       Response.parse(xml)
     end
   end

--- a/lib/tww/testing.rb
+++ b/lib/tww/testing.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'tww/client'
 
 module TWW

--- a/lib/tww/version.rb
+++ b/lib/tww/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module TWW
-  VERSION = '1.1.0'
+  VERSION = '1.2.0'
 end


### PR DESCRIPTION
[KZ4112](https://clicksign.kanbanize.com/ctrl_board/28/cards/4112/details/)

Segue abaixo comandos para instalar a gem localmente e validar se o código esta ok.

Comando:
`gem build tww.gemspec`
Resultado esperado:
```
  Successfully built RubyGem
  Name: tww
  Version: 1.2.0
  File: tww-1.2.0.gem
```
Comando:
`gem install tww`
Resultado esperado:
```
Successfully installed tww-1.2.0
Parsing documentation for tww-1.2.0
Installing ri documentation for tww-1.2.0
Done installing documentation for tww after 0 seconds
1 gem installed
```

Código para testar através do irb:
```
require 'tww'

TWW_USERNAME = 'CLICKSIGN'
TWW_PASSWORD = 'DESEN17'
TWW_FROM = '27800'

TWW.config do |config|
  config.username = TWW_USERNAME
  config.password = TWW_PASSWORD
  config.from = TWW_FROM
  config.timeout = 180 # Config.default['tww_timeout']
end

client = TWW.client
client.deliver('49988172349', 'Hello World using old fashioned SMS')

```